### PR TITLE
[nightshift] docs-backfill: add JSDoc documentation to all 21 JS modules

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,8 @@
-// Wire up dragging, tabs, warnings, and sounds (equal chance for every scenario)
+/**
+ * @fileoverview Main application bootstrap for Quarzite desktop.
+ * Wires up window dragging, tabs, warnings, sounds, and random scenario selection.
+ * Handles the easter egg tree and Clippy quote rotation.
+ */
 (function () {
   document.addEventListener("DOMContentLoaded", () => {
     const desktop = document.getElementById("desktop");

--- a/js/background.js
+++ b/js/background.js
@@ -1,5 +1,15 @@
+/**
+ * @fileoverview Background theme utilities for Quarzite.
+ * Provides color conversion (hex/RGB/HSL), palette generation, and theme application.
+ * @exports window.BackgroundTheme
+ */
 (function () {
   const BackgroundTheme = {
+    /**
+     * Convert a hex color string to RGB components.
+     * @param {string} hex - Hex color string (3 or 6 digits, with or without #).
+     * @returns {{r: number, g: number, b: number}} RGB values (0-255).
+     */
     hexToRgb(hex) {
       let value = hex.replace("#", "");
       if (value.length === 3) {
@@ -16,6 +26,13 @@
       };
     },
 
+    /**
+     * Convert RGB values to HSL color space.
+     * @param {number} r - Red (0-255).
+     * @param {number} g - Green (0-255).
+     * @param {number} b - Blue (0-255).
+     * @returns {{h: number, s: number, l: number}} HSL values (h: 0-360, s/l: 0-1).
+     */
     rgbToHsl(r, g, b) {
       const red = r / 255;
       const green = g / 255;

--- a/js/clippy.js
+++ b/js/clippy.js
@@ -1,3 +1,8 @@
+/**
+ * @fileoverview Clippy-style quote displayer for Quarzite desktop.
+ * Shows a random quote from a curated collection in a Windows 98-style
+ * Clippy assistant window. Includes animation and sound effects.
+ */
 const quotes = [
   "Mercy to the guilty is cruelty to the innocent.", // Adam Smith, *The Theory of Moral Sentiments* (1759)
   "The dog that weeps after it kills is no different to the dog that doesn't. My guilt will not purify me.",

--- a/js/controls.js
+++ b/js/controls.js
@@ -1,4 +1,7 @@
-// Volume + Animation controls
+/**
+ * @fileoverview Volume slider and animation toggle controls for Quarzite desktop.
+ * Persists volume level to localStorage and exposes it via window.AppVolume.
+ */
 (function () {
   const STORAGE_KEY = "quarziteVolume";
   const volumeBtn = document.getElementById("volume-toggle");
@@ -10,6 +13,10 @@
   const body = document.body;
 
   // --- Volume ---
+  /**
+   * Apply the volume level: update global state, persist, and update icon.
+   * @param {number} vol - Volume level (0-100).
+   */
   function applyVolume(vol) {
     window.AppVolume = vol;
     localStorage.setItem(STORAGE_KEY, vol);
@@ -21,6 +28,11 @@
     }
   }
 
+  /**
+   * Load persisted volume from localStorage and apply it.
+   * Defaults to 100 if no saved value exists.
+   * @returns {number} The loaded volume level.
+   */
   function loadVolume() {
     let vol = parseInt(localStorage.getItem(STORAGE_KEY), 10);
     if (isNaN(vol)) vol = 100;

--- a/js/debug.js
+++ b/js/debug.js
@@ -1,5 +1,8 @@
-// js/debug.js
-// Debug mode: resize grips + coordinate labels + Copy CSS
+/**
+ * @fileoverview Debug mode for Quarzite desktop.
+ * Adds resize grips with coordinate labels and CSS copy functionality.
+ * @exports window.AppDebug
+ */
 (function () {
   const grips = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
   let enabled = false;

--- a/js/drag.js
+++ b/js/drag.js
@@ -1,9 +1,20 @@
-// Drag windows by title bar (mouse + touch), clamped to desktop
+/**
+ * @fileoverview Window dragging system for Quarzite desktop.
+ * Supports mouse and touch events with viewport clamping.
+ * @exports window.AppDrag
+ */
 (function () {
   function px(n) {
     return Number.parseFloat(n || "0");
   }
 
+  /**
+   * Make an element draggable by a handle, clamped within a container.
+   * Supports both mouse and touch input. Respects the current desktop scale.
+   * @param {HTMLElement} el - The element to make draggable.
+   * @param {HTMLElement} handle - The drag handle (typically the title bar).
+   * @param {HTMLElement} container - The bounding container for clamping.
+   */
   function makeDraggable(el, handle, container) {
     let dragging = false;
     let startX = 0;

--- a/js/gallery-shared.js
+++ b/js/gallery-shared.js
@@ -1,3 +1,9 @@
+/**
+ * @fileoverview Shared gallery utilities for Quarzite desktop and mobile views.
+ * Provides HTML sanitization, URL validation, date formatting, gallery loading,
+ * image item creation, and viewer metadata/description rendering.
+ * @exports window.GalleryShared
+ */
 (function () {
   const ALLOWED_RICH_TEXT_TAGS = new Set([
     "a",
@@ -13,11 +19,21 @@
     "ul",
   ]);
 
+  /**
+   * Safely convert any value to a string.
+   * @param {*} value - The value to convert.
+   * @returns {string} The string representation, or empty string for null/undefined.
+   */
   function toText(value) {
     if (value == null) return "";
     return typeof value === "string" ? value : String(value);
   }
 
+  /**
+   * Validate and sanitize a URL, allowing only http, https, and mailto protocols.
+   * @param {*} value - The URL to sanitize.
+   * @returns {string} The validated URL string, or empty string if invalid.
+   */
   function sanitizeUrl(value) {
     const href = toText(value).trim();
     if (!href) return "";
@@ -40,6 +56,11 @@
     return "";
   }
 
+  /**
+   * Recursively sanitize a DOM node, removing disallowed tags and dangerous attributes.
+   * @param {Node} node - The DOM node to sanitize.
+   * @param {Document} doc - The document context.
+   */
   function sanitizeNode(node, doc) {
     if (node.nodeType === Node.TEXT_NODE) {
       return doc.createTextNode(node.textContent || "");
@@ -83,6 +104,12 @@
     return clean;
   }
 
+  /**
+   * Render sanitized rich HTML into a target element.
+   * Strips all tags except a whitelist of safe inline/block elements.
+   * @param {HTMLElement} target - The container element.
+   * @param {string} html - The raw HTML string to sanitize and render.
+   */
   function renderRichText(target, html) {
     const doc = target.ownerDocument;
     const parser = new DOMParser();
@@ -96,6 +123,11 @@
     target.replaceChildren(fragment);
   }
 
+  /**
+   * Format a date value into a localized human-readable string.
+   * @param {string|Date} value - The date to format.
+   * @returns {string} Formatted date string (e.g. "Jan 15, 2025"), or empty string.
+   */
   function formatDate(value) {
     if (!value) return null;
 
@@ -111,6 +143,12 @@
     return value;
   }
 
+  /**
+   * Resolve an image asset path, prepending a prefix if the src is relative.
+   * @param {string} src - The image source path.
+   * @param {string} prefix - The prefix to prepend for relative paths.
+   * @returns {string} The resolved absolute or prefixed path.
+   */
   function resolveAssetPath(src, prefix) {
     const value = toText(src).trim();
     if (!value) return "";
@@ -120,6 +158,12 @@
     return `${prefix || ""}${value}`;
   }
 
+  /**
+   * Normalize a gallery item object, resolving asset paths and extracting metadata.
+   * @param {Object} item - Raw gallery item from JSON.
+   * @param {Object} options - Options including srcPrefix.
+   * @returns {Object} Normalized item with resolved src, artist, date, and desc.
+   */
   function normalizeItem(item, options) {
     const config = options || {};
     const source =
@@ -144,6 +188,11 @@
     };
   }
 
+  /**
+   * Sort gallery items by date in descending order (newest first).
+   * @param {Object[]} items - Array of gallery items with date fields.
+   * @returns {Object[]} The sorted array.
+   */
   function sortImagesByDate(items) {
     return items.slice().sort((a, b) => {
       if (!a.date) return 1;
@@ -152,6 +201,13 @@
     });
   }
 
+  /**
+   * Fetch and parse a gallery JSON file, normalizing and sorting items.
+   * @async
+   * @param {string} url - URL to the gallery JSON file.
+   * @param {Object} [options] - Options passed to normalizeItem (e.g. srcPrefix).
+   * @returns {Promise<Object[]>} Array of normalized gallery items, newest first.
+   */
   async function loadGallery(url, options) {
     let response;
     try {
@@ -180,6 +236,13 @@
     );
   }
 
+  /**
+   * Create a DOM element for a gallery image item.
+   * @param {Object} item - Normalized gallery item.
+   * @param {number} index - Index in the gallery array.
+   * @param {Object} options - Config: className, alt, ariaLabel, draggable.
+   * @returns {HTMLElement} The gallery item element with data-index attribute.
+   */
   function createGalleryItem(item, index, options) {
     const config = options || {};
     const wrapper = document.createElement("div");
@@ -207,6 +270,11 @@
     return wrapper;
   }
 
+  /**
+   * Render an error message into a target element when gallery loading fails.
+   * @param {HTMLElement} target - The container to show the error in.
+   * @param {string} message - The error message to display.
+   */
   function renderLoadError(target, message) {
     const notice = document.createElement("div");
     notice.className = "gallery-error";
@@ -216,6 +284,12 @@
     target.replaceChildren(notice);
   }
 
+  /**
+   * Determine whether to display the artist name.
+   * @param {string} name - The artist name.
+   * @param {boolean} hideUnknownArtist - Whether to hide unknown/empty artists.
+   * @returns {boolean} True if the artist name should be shown.
+   */
   function shouldShowArtist(name, hideUnknownArtist) {
     const value = toText(name).trim();
     if (!value) return false;
@@ -225,6 +299,11 @@
     return true;
   }
 
+  /**
+   * Render viewer metadata (artist, date, separator) into a target element.
+   * @param {HTMLElement} target - The metadata container.
+   * @param {Object} options - Config: artistFirst, artistName, artistPrefix, artistUrl, dateText, separator, hideUnknownArtist.
+   */
   function renderViewerMeta(target, options) {
     const config = options || {};
     const dateText = toText(config.dateText).trim();
@@ -279,6 +358,11 @@
     target.hidden = parts.length === 0;
   }
 
+  /**
+   * Render sanitized rich text description into a viewer description element.
+   * @param {HTMLElement} target - The description container.
+   * @param {string} html - Raw HTML description to sanitize and render.
+   */
   function renderViewerDescription(target, html) {
     const content = toText(html).trim();
     if (!content) {

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,6 +1,11 @@
-// Gallery: load images and open viewer window with metadata
+/**
+ * @fileoverview Desktop gallery viewer for Quarzite.
+ * Loads images from gallery.json, builds gallery strip with slots,
+ * and opens a full viewer window with metadata overlay.
+ */
 (function () {
   const GalleryShared = window.GalleryShared;
+  /** @type {Object[]} Loaded gallery images */
   let images = [];
   let strip;
   let viewer;
@@ -15,6 +20,12 @@
 
   const px = (v) => Math.max(0, parseFloat(v || 0));
 
+  /**
+   * Build a gallery slot element for an image.
+   * @param {Object} imgObj - Normalized gallery item.
+   * @param {number} index - Index in the gallery array.
+   * @returns {HTMLElement} The gallery slot element.
+   */
   function buildSlot(imgObj, index) {
     return GalleryShared.createGalleryItem(imgObj, index, {
       className: "slot",
@@ -22,6 +33,10 @@
     });
   }
 
+  /**
+   * Bring a window element to the front by setting the highest z-index.
+   * @param {HTMLElement} win - The window element to promote.
+   */
   function bringToFront(win) {
     const wins = Array.from(document.querySelectorAll(".app-window"));
     const top = wins.reduce((max, current) => {

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,8 +1,20 @@
+/**
+ * @fileoverview Desktop scaling and layout system for Quarzite.
+ * Scales the 1920x1080 design viewport to fit the browser window.
+ * @exports window.AppLayout
+ */
 (function () {
+  /** @const {number} Design viewport width in pixels */
   const DESIGN_WIDTH = 1920;
+  /** @const {number} Design viewport height in pixels */
   const DESIGN_HEIGHT = 1080;
+  /** @type {number} Current scale factor */
   let currentScale = 1;
 
+  /**
+   * Compute the optimal scale factor to fit the design viewport.
+   * @returns {number} Scale factor (0 to 1), clamped to max 1.
+   */
   function computeScale() {
     return Math.min(
       window.innerWidth / DESIGN_WIDTH,
@@ -11,6 +23,10 @@
     );
   }
 
+  /**
+   * Synchronize the desktop layout by updating CSS custom properties.
+   * Sets --desktop-scale and --desktop-offset-top, and toggles compact-layout class.
+   */
   function syncLayout() {
     currentScale = Math.max(0.52, computeScale());
 
@@ -30,6 +46,11 @@
     document.body.classList.toggle("compact-layout", currentScale < 0.8);
   }
 
+  /**
+   * Convert screen pixels to design-space pixels using the current scale.
+   * @param {number} screenPx - Pixel value in screen space.
+   * @returns {number} Equivalent pixel value in design space.
+   */
   function toDesignPx(screenPx) {
     return screenPx / currentScale;
   }

--- a/js/logo.js
+++ b/js/logo.js
@@ -1,4 +1,9 @@
+/**
+ * @fileoverview Random logo selector for Quarzite desktop.
+ * Picks one of the available logo GIFs at random on page load.
+ */
 (function () {
+  /** @const {string[]} Available logo images */
   const LOGOS = ["assets/quarzitelogo3.gif", "assets/quarzitelogo4.gif"];
 
   document.addEventListener("DOMContentLoaded", () => {

--- a/js/mobile-gallery.js
+++ b/js/mobile-gallery.js
@@ -1,4 +1,8 @@
-// Load gallery from ../data/gallery.json (newest -> oldest), 1:1 contain
+/**
+ * @fileoverview Mobile gallery grid for Quarzite.
+ * Loads images from gallery.json (newest to oldest) and builds a responsive grid.
+ * Clicking an item opens it in the mobile viewer.
+ */
 (function () {
   const GalleryShared = window.GalleryShared;
   let grid;

--- a/js/mobile-sounds.js
+++ b/js/mobile-sounds.js
@@ -1,4 +1,8 @@
-// Use the same files as desktop, but with a base that works from assets/mobile.html
+/**
+ * @fileoverview Mobile sound effects player for Quarzite.
+ * Uses the same sound files as desktop but with paths relative to mobile.html.
+ * @exports window.W98.play (augments desktop W98 if not already set)
+ */
 (function () {
   const base = "w98sounds/"; // relative to assets/mobile.html
 

--- a/js/mobile-tabs.js
+++ b/js/mobile-tabs.js
@@ -1,4 +1,7 @@
-// Top-level tabs + inner info tabs with W98 sounds
+/**
+ * @fileoverview Mobile tab navigation for Quarzite.
+ * Manages main navigation tabs and inner info tabs with W98 click sounds.
+ */
 (function () {
   function sfx(name) {
     try {

--- a/js/mobile-viewer.js
+++ b/js/mobile-viewer.js
@@ -1,4 +1,8 @@
-// 98.css viewer modal with meta + desc + W98 sounds and author title
+/**
+ * @fileoverview Mobile gallery viewer modal for Quarzite.
+ * Displays artwork in a fullscreen modal with metadata, description, and W98 sounds.
+ * @exports window.MobileGalleryViewer
+ */
 (function () {
   const GalleryShared = window.GalleryShared;
 

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -1,5 +1,13 @@
-// Notepad: multiple random versions + classic menu + wrapping + random offset
+/**
+ * @fileoverview Windows 98-style Notepad for Quarzite desktop.
+ * Randomly selects from multiple text versions (ASCII art, reports, poems),
+ * applies Fixedsys font, and provides word-wrap toggle with menu bar.
+ */
 (function () {
+  /**
+   * Set the notepad font size and line height.
+   * @param {number} px - Font size in pixels.
+   */
   function setFontPx(px) {
     const ta = document.getElementById("notepad-text");
     ta.style.fontSize = px + "px";
@@ -7,7 +15,10 @@
     ta.style.fontFamily = '"FixedsysWin98", "Fixedsys", monospace';
   }
 
-  // Force wrapping via inline styles so CSS can't override it
+  /**
+   * Force word wrapping via inline styles so CSS can't override it.
+   * @param {boolean} isWrap - True to enable word wrap, false to disable.
+   */
   function applyWrap(isWrap) {
     const ta = document.getElementById("notepad-text");
     ta.classList.remove("notepad-wrap", "notepad-nowrap");

--- a/js/res-warning.js
+++ b/js/res-warning.js
@@ -1,6 +1,14 @@
+/**
+ * @fileoverview Resolution compatibility warning for Quarzite.
+ * Detects if the viewport is too small and shows a warning modal.
+ * Users can opt out permanently via localStorage.
+ */
 (() => {
+  /** @const {string} localStorage key for opt-out preference */
   const OPT_OUT_KEY = "resWarn:optOut";
+  /** @const {number} Minimum recommended viewport width */
   const MIN_WIDTH = 1180;
+  /** @const {number} Minimum recommended viewport height */
   const MIN_HEIGHT = 700;
   // Initial load only (no resize re-check)
   const USE_RESIZE_RECHECK = false;

--- a/js/run.js
+++ b/js/run.js
@@ -1,3 +1,7 @@
+/**
+ * @fileoverview Console branding for Quarzite.
+ * Displays the Quarzite logo as a CSS background image in the browser console.
+ */
 const gifAssetUrl = new URL("assets/quarzitelogo4.gif", window.location.href).href;
 
 const styles = [

--- a/js/sounds.js
+++ b/js/sounds.js
@@ -1,6 +1,20 @@
+/**
+ * @fileoverview Windows 98 sound effects player for Quarzite desktop.
+ * Maps sound names to audio files and plays them at the current AppVolume level.
+ * @exports window.W98
+ */
 (function () {
+  /** @const {string} Base path for sound effect files */
   const base = "assets/w98sounds/";
 
+  /**
+   * @typedef {Object} SoundFiles
+   * @property {string} chord - Chord sound file
+   * @property {string} recycle - Recycle bin sound file
+   * @property {string} click - Click sound file
+   * @property {string} hideBar - Hide bar sound file
+   * @property {string} microsoft - Easter egg Microsoft sound file
+   */
   const files = {
     chord: "CHORD.mp3",
     recycle: "RECYCLE.mp3",
@@ -9,6 +23,10 @@
     microsoft: "The Microsoft Sound.mp3", // Easter Egg sound
   };
 
+  /**
+   * Play a named sound effect.
+   * @param {string} name - Sound name key from the files map.
+   */
   function play(name) {
     const f = files[name];
     if (!f) return;

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,5 +1,14 @@
-// 98.css Tabs: prevent URL hash and toggle aria/hidden
+/**
+ * @fileoverview 98.css-style tab system with keyboard navigation.
+ * Manages tab selection, ARIA attributes, and panel visibility.
+ * @exports window.Tabs
+ */
 (function () {
+  /**
+   * Initialize a 98.css tab container with click and keyboard handlers.
+   * Prevents default hash navigation and manages aria-selected/hidden states.
+   * @param {HTMLElement} container - The tab container element.
+   */
   function initTabs98(container) {
     if (!container) return;
 

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -1,4 +1,7 @@
-// Tile background switcher
+/**
+ * @fileoverview Tile background switcher for Quarzite desktop.
+ * Cycles through tiled background images and persists selection to localStorage.
+ */
 (function () {
   const tiles = [
     "assets/tiles/tile1.png",
@@ -13,6 +16,10 @@
   const root = document.body; // or document.documentElement
   const STORAGE_KEY = "quarziteTileIndex";
 
+  /**
+   * Apply a tile background by index.
+   * @param {number} index - Index into the tiles array.
+   */
   function applyTile(index) {
     const tile = tiles[index] || tiles[0];
     root.style.backgroundImage = `url("${tile}")`;

--- a/js/warning.js
+++ b/js/warning.js
@@ -1,4 +1,8 @@
-// Warning popup + intercept title-bar controls
+/**
+ * @fileoverview Warning popup modal and title-bar control interceptor.
+ * Prevents minimize/maximize/close on windows and shows a warning instead.
+ * @exports window.AppWarning
+ */
 (function () {
   let backdrop, modal, msgEl, okBtn, closeBtn;
 
@@ -38,6 +42,14 @@
     modal.hidden = true;
   }
 
+  /**
+   * Attach title-bar control interceptors to all app windows.
+   * Intercepts minimize/maximize/close buttons and double-clicks,
+   * showing a warning popup instead. Windows in the exclude list are skipped.
+   * @param {HTMLElement} root - The root element to search for windows.
+   * @param {Object} [options] - Options.
+   * @param {string[]} [options.exclude=[]] - Window IDs to exclude from interception.
+   */
   function attachControls(root, { exclude = [] } = {}) {
     const excludeSet = new Set(exclude);
 


### PR DESCRIPTION
Automated by [Nightshift v3](https://github.com/marcus/nightshift) (GLM 5.1).

**Task:** docs-backfill (Documentation Backfiller)
**Category:** pr
**Changes:** Added JSDoc documentation to all 21 JavaScript modules in `js/` directory.

### Summary

Adds comprehensive JSDoc `@fileoverview`, `@param`, `@returns`, `@typedef`, and `@exports` annotations to every JS module:

- **gallery-shared.js** — 12 functions documented (sanitization, formatting, loading, rendering)
- **layout.js** — Desktop scaling system (DESIGN_WIDTH/HEIGHT, computeScale, syncLayout, toDesignPx)
- **drag.js** — Window dragging with mouse/touch support (makeDraggable)
- **controls.js** — Volume slider and animation toggle
- **background.js** — Color conversion utilities (hexToRgb, rgbToHsl)
- **tabs.js** — 98.css tab navigation with keyboard support
- **gallery.js** — Desktop gallery viewer with metadata
- **warning.js** — Warning popup and title-bar control interceptor
- **tiles.js** — Background tile switcher
- **sounds.js** — Windows 98 sound effects player
- **notepad.js** — Random notepad content with font/wrap controls
- **clippy.js** — Quote display system
- **debug.js** — Debug mode with resize grips
- **mobile-\*.js** — Mobile gallery, viewer, tabs, sounds
- **res-warning.js** — Resolution compatibility warning
- **logo.js** — Random logo selector
- **run.js** — Console branding
- **app.js** — Main application bootstrap

**21 files changed, +276 lines of documentation.** No functional changes.

Merge if useful, close if not.